### PR TITLE
Add "void" as return type, which fix deprecation notices

### DIFF
--- a/src/DependencyInjection/CompilerPass/ActivatorPass.php
+++ b/src/DependencyInjection/CompilerPass/ActivatorPass.php
@@ -17,7 +17,7 @@ class ActivatorPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $bag = $container->getDefinition('flagception.activator.chain_activator');
 

--- a/src/DependencyInjection/CompilerPass/ContextDecoratorPass.php
+++ b/src/DependencyInjection/CompilerPass/ContextDecoratorPass.php
@@ -17,7 +17,7 @@ class ContextDecoratorPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $bag = $container->getDefinition('flagception.decorator.chain_decorator');
 

--- a/src/DependencyInjection/CompilerPass/ExpressionProviderPass.php
+++ b/src/DependencyInjection/CompilerPass/ExpressionProviderPass.php
@@ -17,7 +17,7 @@ class ExpressionProviderPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         $factory = $container->getDefinition('flagception.factory.expression_language_factory');
 

--- a/src/DependencyInjection/FlagceptionExtension.php
+++ b/src/DependencyInjection/FlagceptionExtension.php
@@ -23,7 +23,7 @@ class FlagceptionExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('configurators.yml');

--- a/src/FlagceptionBundle.php
+++ b/src/FlagceptionBundle.php
@@ -19,7 +19,7 @@ class FlagceptionBundle extends Bundle
     /**
      * {@inheritdoc}
      */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         parent::build($container);
 

--- a/src/Profiler/FeatureDataCollector.php
+++ b/src/Profiler/FeatureDataCollector.php
@@ -47,7 +47,7 @@ class FeatureDataCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function collect(Request $request, Response $response, Throwable $exception = null)
+    public function collect(Request $request, Response $response, Throwable $exception = null): void
     {
         $this->data = [
             'summary' => [
@@ -200,7 +200,7 @@ class FeatureDataCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function reset()
+    public function reset(): void
     {
         $this->data = [];
     }


### PR DESCRIPTION
Adding native return types prepare us for next Symfony versions (7 and 8) - https://symfony.com/blog/symfony-7-0-type-declarations

At the moment unit tests fail, because the package [flagception-database-activator](https://github.com/playox/flagception-database-activator/tree/master) use syntax for PHP 7.3, but in composer.json requires php 7.1 (https://github.com/playox/flagception-database-activator/blob/2cc00ecea62f3aff3fd5ed3f5e37341f62247000/composer.json#L14).
I will prepare PR for this too.