### PR TITLE
remove testing keyword, for not trigger dev-req on composer require

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "flagception/flagception-bundle",
   "type": "symfony-bundle",
   "description": "Feature toggle bundle on steroids.",
-  "keywords": ["feature", "feature-toggle", "feature-flags", "flags", "flagception", "symfony", "bundle", "rollout", "testing", "toggle"],
+  "keywords": ["feature", "feature-toggle", "feature-flags", "flags", "flagception", "symfony", "bundle", "rollout", "toggle"],
   "license": "MIT",
   "authors": [
     {


### PR DESCRIPTION
By design this bundle is not a `require-dev` dependency, so remove the `testing` tag to not show the following message on composer require:

```
composer require flagception/flagception-bundle
The package you required is recommended to be placed in require-dev (because it is tagged as "testing") but you did not use --dev.
Do you want to re-run the command with --dev? [yes]? no
```
