### PR TITLE
update composer.json for Symfony 6.4 and 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,18 +11,18 @@
     }
   ],
   "require": {
-    "php": "^7.1.3 | ^8",
-    "symfony/dependency-injection": "^4.4 | ^5.0 | ^6.0",
-    "symfony/yaml": "^4.4 | ^5.0 | ^6.0",
-    "symfony/config": "^4.4 | ^5.0 | ^6.0",
-    "symfony/http-kernel": "^4.4 | ^5.0 | ^6.0",
+    "php": "^7.1.3 | ^8.0",
+    "symfony/dependency-injection": "^4.4 | ^5.0 | ^6.0 | ^7.0",
+    "symfony/yaml": "^4.4 | ^5.0 | ^6.0 | ^7.0",
+    "symfony/config": "^4.4 | ^5.0 | ^6.0 | ^7.0",
+    "symfony/http-kernel": "^4.4 | ^5.0 | ^6.0 | ^7.0",
     "twig/twig": "^1.18|^2.0|^3.0",
     "doctrine/annotations": "^1.7 | ^2.0",
     "flagception/flagception": "^1.5"
   },
   "require-dev": {
-    "symfony/phpunit-bridge": "^5.0 | ^6.0",
-    "symfony/twig-bridge": "^4.4 | ^5.0 | ^6.0",
+    "symfony/phpunit-bridge": "^5.0 | ^6.0 | ^7.0",
+    "symfony/twig-bridge": "^4.4 | ^5.0 | ^6.0 | ^7.0",
     "flagception/database-activator": "^1.0",
     "squizlabs/php_codesniffer": "^3.3.1",
     "php-coveralls/php-coveralls": "^2.0"

--- a/tests/Listener/RoutingMetadataSubscriberTest.php
+++ b/tests/Listener/RoutingMetadataSubscriberTest.php
@@ -121,7 +121,7 @@ class RoutingMetadataSubscriberTest extends TestCase
             $this->createMock(HttpKernelInterface::class),
             [$this, 'testFeatureIsActive'],
             $request,
-            HttpKernelInterface::MASTER_REQUEST
+            1 /* HttpKernelInterface::MAIN_REQUEST */
         );
     }
 
@@ -142,7 +142,7 @@ class RoutingMetadataSubscriberTest extends TestCase
                 return new Response();
             },
             $request,
-            HttpKernelInterface::MASTER_REQUEST
+            1 /* HttpKernelInterface::MAIN_REQUEST */
         );
 
         $manager = $this->createMock(FeatureManagerInterface::class);
@@ -171,7 +171,7 @@ class RoutingMetadataSubscriberTest extends TestCase
                 return new Response();
             },
             $request,
-            HttpKernelInterface::MASTER_REQUEST
+            1 /* HttpKernelInterface::MAIN_REQUEST */
         );
 
         $manager = $this->createMock(FeatureManagerInterface::class);


### PR DESCRIPTION
Bundle should be already compatible with 6.4 and therefore also 7.0. Some tests needed to be changed and PhpUnit deprecated usages are replaced by that also.

fyi: For having a full test suite for this bundle https://github.com/playox/flagception-database-activator/blob/master/composer.json#L16 would need to allow `doctrine/dbal` ^3.