### PR TITLE
Fix PHP 8.4 deprecations and add some typing

### DIFF
--- a/src/Activator/TraceableChainActivator.php
+++ b/src/Activator/TraceableChainActivator.php
@@ -23,7 +23,7 @@ class TraceableChainActivator extends ChainActivator
     /**
      * {@inheritdoc}
      */
-    public function isActive($name, Context $context): bool
+    public function isActive($name, ?Context $context): bool
     {
         $stack = [];
         $result = false;
@@ -52,7 +52,7 @@ class TraceableChainActivator extends ChainActivator
      *
      * @return array
      */
-    public function getTrace()
+    public function getTrace(): array
     {
         return $this->trace;
     }

--- a/src/Profiler/FeatureDataCollector.php
+++ b/src/Profiler/FeatureDataCollector.php
@@ -47,7 +47,7 @@ class FeatureDataCollector extends DataCollector
     /**
      * {@inheritdoc}
      */
-    public function collect(Request $request, Response $response, Throwable $exception = null): void
+    public function collect(Request $request, Response $response, ?Throwable $exception = null): void
     {
         $this->data = [
             'summary' => [


### PR DESCRIPTION
Hi,

Following https://github.com/playox/flagception-sdk/pull/8, this is a pull request to add PHP 8.4 support to Symfony flagception-bundle.

I was able to run all the sdk tests, but I wasn't able to run some of the tests in this repository (db flags, etc.). If you would please recheck these, that would be appreciated.