### PR TITLE
Replace HttpKernel Extension with DependencyInjection Extension

### DIFF
--- a/src/DependencyInjection/FlagceptionExtension.php
+++ b/src/DependencyInjection/FlagceptionExtension.php
@@ -7,9 +7,9 @@ use Flagception\Activator\FeatureActivatorInterface;
 use Flagception\Bundle\FlagceptionBundle\Activator\TraceableChainActivator;
 use Flagception\Bundle\FlagceptionBundle\DependencyInjection\Configurator\ActivatorConfiguratorInterface;
 use Flagception\Decorator\ContextDecoratorInterface;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Config\FileLocator;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader;
 
 /**


### PR DESCRIPTION
Symfony 7.1 marks [Symfony\Component\HttpKernel\DependencyInjection\Extension](https://github.com/symfony/http-kernel/blob/7.1/DependencyInjection/Extension.php#L21) as internal and schedules it for removal in 8.1. FlagceptionExtension currently extends this class, which triggers deprecation warnings.